### PR TITLE
Output validation issues to console.

### DIFF
--- a/1.12/fixtures/configurable_products.php
+++ b/1.12/fixtures/configurable_products.php
@@ -836,8 +836,11 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('catalog_product');
 $import->setBehavior('append');
 
-$source = new \Magento\ToolkitFramework\ImportExport\Fixture\Complex\Generator($pattern, $configurablesCount);
+$generator = new \Magento\ToolkitFramework\ImportExport\Fixture\Complex\Generator($pattern, $configurablesCount);
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$source);
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}
 // this converts import queue into actual entities
 $import->importSource();

--- a/1.12/fixtures/customers.php
+++ b/1.12/fixtures/customers.php
@@ -71,6 +71,9 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('customer');
 $import->setBehavior('append');
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$generator);
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}
 // this converts import queue into actual entities
 $import->importSource();

--- a/1.12/fixtures/simple_products.php
+++ b/1.12/fixtures/simple_products.php
@@ -91,6 +91,8 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('catalog_product');
 $import->setBehavior('append');
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$generator);
-// this converts import queue into actual entities
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}// this converts import queue into actual entities
 $import->importSource();

--- a/1.13/fixtures/configurable_products.php
+++ b/1.13/fixtures/configurable_products.php
@@ -836,8 +836,11 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('catalog_product');
 $import->setBehavior('append');
 
-$source = new \Magento\ToolkitFramework\ImportExport\Fixture\Complex\Generator($pattern, $configurablesCount);
+$generator = new \Magento\ToolkitFramework\ImportExport\Fixture\Complex\Generator($pattern, $configurablesCount);
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$source);
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}
 // this converts import queue into actual entities
 $import->importSource();

--- a/1.13/fixtures/customers.php
+++ b/1.13/fixtures/customers.php
@@ -71,6 +71,9 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('customer');
 $import->setBehavior('append');
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$generator);
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}
 // this converts import queue into actual entities
 $import->importSource();

--- a/1.13/fixtures/simple_products.php
+++ b/1.13/fixtures/simple_products.php
@@ -91,6 +91,9 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('catalog_product');
 $import->setBehavior('append');
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$generator);
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}
 // this converts import queue into actual entities
 $import->importSource();

--- a/1.14/fixtures/configurable_products.php
+++ b/1.14/fixtures/configurable_products.php
@@ -836,8 +836,11 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('catalog_product');
 $import->setBehavior('append');
 
-$source = new \Magento\ToolkitFramework\ImportExport\Fixture\Complex\Generator($pattern, $configurablesCount);
+$generator = new \Magento\ToolkitFramework\ImportExport\Fixture\Complex\Generator($pattern, $configurablesCount);
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$source);
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}
 // this converts import queue into actual entities
 $import->importSource();

--- a/1.14/fixtures/customers.php
+++ b/1.14/fixtures/customers.php
@@ -71,6 +71,9 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('customer');
 $import->setBehavior('append');
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$generator);
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}
 // this converts import queue into actual entities
 $import->importSource();

--- a/1.14/fixtures/simple_products.php
+++ b/1.14/fixtures/simple_products.php
@@ -91,6 +91,9 @@ $import = Mage::getModel('importexport/import');
 $import->setEntity('catalog_product');
 $import->setBehavior('append');
 // it is not obvious, but the validateSource() will actually save import queue data to DB
-$import->validateSource((string)$generator);
+$result = $import->validateSource((string)$generator);
+if ($result === false) {
+    echo PHP_EOL . $import->getFormatedLogTrace();
+}
 // this converts import queue into actual entities
 $import->importSource();


### PR DESCRIPTION
Fixture file validation errors should be displayed to console.
You can test it by making some attribute which is not present
in the fixture required in the magento backend. e.g. media_gallery

Without this patch you will get some not meaningful error like "'Error in data structure: entity codes are mixed'"